### PR TITLE
Fix: Add support for custom headers in streamableHttp servers

### DIFF
--- a/src/McpClient.ts
+++ b/src/McpClient.ts
@@ -100,6 +100,7 @@ export interface McpClientConfig {
   // For HTTP/SSE
   url?: string;
   transport?: 'stdio' | 'streamableHttp' | 'sse';
+  headers?: Record<string, string>; // <-- ADD THIS LINE
 }
 
 export interface Annotated {
@@ -316,6 +317,7 @@ export class McpClient {
             'Content-Type': 'application/json',
             Accept: 'application/json, text/event-stream',
             'MCP-Protocol-Version': PROTOCOL_VERSION,
+			...this.config.headers, // <-- ADD THIS LINE to merge custom headers
           };
           if (this.sessionId) {
             headers['Mcp-Session-Id'] = this.sessionId;
@@ -523,6 +525,7 @@ export class McpClient {
           'Content-Type': 'application/json',
           Accept: 'application/json, text/event-stream',
           'MCP-Protocol-Version': this.negotiatedProtocolVersion,
+		  ...this.config.headers, // <-- ADD THIS LINE
         };
         if (this.sessionId) {
           headers['Mcp-Session-Id'] = this.sessionId;
@@ -617,6 +620,7 @@ export class McpClient {
         'Content-Type': 'application/json',
         Accept: 'application/json, text/event-stream',
         'MCP-Protocol-Version': this.negotiatedProtocolVersion,
+		...this.config.headers, // <-- ADD THIS LINE
       };
       if (this.sessionId) {
         headers['Mcp-Session-Id'] = this.sessionId;

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,6 +6,7 @@ import { exec } from 'child_process';
 const ID = 'mcp';
 
 async function init(router: Router): Promise<void> {
+	console.log('<<<< [MCP-BACKEND-PATCH] v1.1 LOADED >>>>'); // <-- ADD THIS LINE
   mcpInit(router);
   // @ts-ignore
   router.post('/open-settings', (request: Request, response) => {

--- a/src/mcp.ts
+++ b/src/mcp.ts
@@ -148,6 +148,7 @@ async function startMcpServer(serverName: string, config: McpServerEntry) {
         url: config.url,
         env: config.env || {},
         transport: transportType,
+		headers: (config as any).headers || {}, // <-- ADD THIS LINE
       },
       createClientInfo(serverName),
       {


### PR DESCRIPTION
addresses the server contribution to errors like  ""error_message": "Malformed API Key passed in. Ensure Key has `Bearer ` prefix. Passed in: "" in MCP servers that expect an authentication key in the header.